### PR TITLE
Fix: Resolve Tailwind CSS PostCSS plugin conflict with Vite

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,6 +1,5 @@
 module.exports = {
   plugins: {
-    tailwindcss: {},
     autoprefixer: {},
   },
 }; 


### PR DESCRIPTION
The Netlify build was failing due to an error indicating that `tailwindcss` was being used directly as a PostCSS plugin in a way that conflicted with Vite's build process.

This commit resolves the issue by removing `tailwindcss` from the `postcss.config.js` file. Vite is capable of automatically detecting and integrating Tailwind CSS when `tailwindcss` is installed and a `tailwind.config.js` file is present.

The `autoprefixer` plugin remains in `postcss.config.js`.

The build process now completes successfully.