### PR TITLE
fix: Resolve ReferenceError for Link and icons in App.jsx

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
-import { Routes, Route } from 'react-router-dom';
+import { Routes, Route, Link } from 'react-router-dom'; // Added Link
+import { FaGithub, FaLinkedin } from 'react-icons/fa'; // Added icon imports
 
 // Import Page Components
 import HomePage from './pages/HomePage';


### PR DESCRIPTION
This commit fixes a `ReferenceError: Link is not defined` that was causing a blank page after the V3 redesign.

The error was due to missing imports in `src/App.jsx`:
- `Link` from `react-router-dom` was used in the Footer but not imported.
- `FaGithub` and `FaLinkedin` from `react-icons/fa` were used in the Footer but not imported.

These missing imports have now been added, and the application builds successfully. This should resolve the blank page issue and allow your V3 redesigned portfolio to render correctly.